### PR TITLE
Extensiones nuevas: DECIMAL & LPAD

### DIFF
--- a/src/DoctrineExtensionsServiceProvider.php
+++ b/src/DoctrineExtensionsServiceProvider.php
@@ -78,6 +78,7 @@ class DoctrineExtensionsServiceProvider extends ServiceProvider
             $configuration->setCustomNumericFunctions([
                 Functions\Postgresql\NumericCastFunction::IDENTIFIER => Functions\Postgresql\NumericCastFunction::class,
                 Functions\Postgresql\EarthDistanceFunction::IDENTIFIER => Functions\Postgresql\EarthDistanceFunction::class,
+                Functions\Postgresql\DecimalCastFunction::IDENTIFIER => Functions\Postgresql\DecimalCastFunction::class,
 
                 'COUNT_FILTER' => BeberleiFunctions\Postgresql\CountFilterFunction::class,
                 'GREATEST' => BeberleiFunctions\Postgresql\Greatest::class,
@@ -91,6 +92,7 @@ class DoctrineExtensionsServiceProvider extends ServiceProvider
                 Functions\Postgresql\FilterWhereFunction::IDENTIFIER => Functions\Postgresql\FilterWhereFunction::class,
                 Functions\Postgresql\InJsonArrayFunction::IDENTIFIER => Functions\Postgresql\InJsonArrayFunction::class,
                 Functions\Postgresql\UnaccentFunction::IDENTIFIER => Functions\Postgresql\UnaccentFunction::class,
+                Functions\Postgresql\LPadFunction::IDENTIFIER => Functions\Postgresql\LPadFunction::class,
 
                 'AT_TIME_ZONE' => BeberleiFunctions\Postgresql\AtTimeZoneFunction::class,
                 'DATE_FORMAT' => BeberleiFunctions\Postgresql\DateFormat::class,

--- a/src/DoctrineExtensionsServiceProvider.php
+++ b/src/DoctrineExtensionsServiceProvider.php
@@ -76,9 +76,9 @@ class DoctrineExtensionsServiceProvider extends ServiceProvider
             ]);
 
             $configuration->setCustomNumericFunctions([
-                Functions\Postgresql\NumericCastFunction::IDENTIFIER => Functions\Postgresql\NumericCastFunction::class,
                 Functions\Postgresql\EarthDistanceFunction::IDENTIFIER => Functions\Postgresql\EarthDistanceFunction::class,
-                Functions\Postgresql\DecimalCastFunction::IDENTIFIER => Functions\Postgresql\DecimalCastFunction::class,
+                Functions\Postgresql\MoneyToDecimalFunction::IDENTIFIER => Functions\Postgresql\MoneyToDecimalFunction::class,
+                Functions\Postgresql\NumericCastFunction::IDENTIFIER => Functions\Postgresql\NumericCastFunction::class,
 
                 'COUNT_FILTER' => BeberleiFunctions\Postgresql\CountFilterFunction::class,
                 'GREATEST' => BeberleiFunctions\Postgresql\Greatest::class,
@@ -91,8 +91,8 @@ class DoctrineExtensionsServiceProvider extends ServiceProvider
                 Functions\Postgresql\DistinctOnFunction::IDENTIFIER => Functions\Postgresql\DistinctOnFunction::class,
                 Functions\Postgresql\FilterWhereFunction::IDENTIFIER => Functions\Postgresql\FilterWhereFunction::class,
                 Functions\Postgresql\InJsonArrayFunction::IDENTIFIER => Functions\Postgresql\InJsonArrayFunction::class,
-                Functions\Postgresql\UnaccentFunction::IDENTIFIER => Functions\Postgresql\UnaccentFunction::class,
                 Functions\Postgresql\LPadFunction::IDENTIFIER => Functions\Postgresql\LPadFunction::class,
+                Functions\Postgresql\UnaccentFunction::IDENTIFIER => Functions\Postgresql\UnaccentFunction::class,
 
                 'AT_TIME_ZONE' => BeberleiFunctions\Postgresql\AtTimeZoneFunction::class,
                 'DATE_FORMAT' => BeberleiFunctions\Postgresql\DateFormat::class,

--- a/src/Functions/Postgresql/DecimalCastFunction.php
+++ b/src/Functions/Postgresql/DecimalCastFunction.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Digbang\DoctrineExtensions\Functions\Postgresql;
+
+use Doctrine\ORM\Query\AST\Functions\FunctionNode;
+use Doctrine\ORM\Query\Lexer;
+use Doctrine\ORM\Query\Parser;
+use Doctrine\ORM\Query\SqlWalker;
+
+/**
+ * Class DecimalCastFunction
+ *
+ * @example DECIMAL($expression, $precision)
+ */
+class DecimalCastFunction extends FunctionNode
+{
+    public const IDENTIFIER = 'DECIMAL';
+
+    private $field;
+    private $precision;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function parse(Parser $parser)
+    {
+        $parser->match(Lexer::T_IDENTIFIER);
+        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $this->field = $parser->ArithmeticExpression();
+        $parser->match(Lexer::T_COMMA);
+        $this->precision = $parser->ScalarExpression();
+        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getSql(SqlWalker $sqlWalker)
+    {
+        $field = $this->field->dispatch($sqlWalker);
+        $precision = $this->precision->dispatch($sqlWalker);
+        $dividend = (int)str_pad('1', $precision + 1, '0', STR_PAD_RIGHT);
+
+        return "(($field)::NUMERIC / $dividend)::NUMERIC(10, $precision)";
+    }
+}

--- a/src/Functions/Postgresql/LPadFunction.php
+++ b/src/Functions/Postgresql/LPadFunction.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Digbang\DoctrineExtensions\Functions\Postgresql;
+
+use Doctrine\ORM\Query\AST\Functions\FunctionNode;
+use Doctrine\ORM\Query\Lexer;
+use Doctrine\ORM\Query\Parser;
+use Doctrine\ORM\Query\SqlWalker;
+
+/**
+ * Class LPadFunction
+ *
+ * @example LPAD($expression, $length, $pad_string)
+ */
+class LPadFunction extends FunctionNode
+{
+    const IDENTIFIER = 'LPAD';
+
+    private $field;
+    private $length;
+    private $padString;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function parse(Parser $parser)
+    {
+        $parser->match(Lexer::T_IDENTIFIER);
+        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $this->field = $parser->StringPrimary();
+        $parser->match(Lexer::T_COMMA);
+        $this->length = $parser->ScalarExpression();
+        $parser->match(Lexer::T_COMMA);
+        $this->padString = $parser->StringPrimary();
+        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getSql(SqlWalker $sqlWalker)
+    {
+        $field = $this->field->dispatch($sqlWalker);
+        $length = $this->length->dispatch($sqlWalker);
+        $padString = $this->padString->dispatch($sqlWalker);
+
+        return "LPAD($field, $length, $padString)";
+    }
+}

--- a/src/Functions/Postgresql/MoneyToDecimalFunction.php
+++ b/src/Functions/Postgresql/MoneyToDecimalFunction.php
@@ -10,11 +10,11 @@ use Doctrine\ORM\Query\SqlWalker;
 /**
  * Class DecimalCastFunction
  *
- * @example DECIMAL($expression, $precision)
+ * @example MONEY_TO_DECIMAL($expression, $precision)
  */
-class DecimalCastFunction extends FunctionNode
+class MoneyToDecimalFunction extends FunctionNode
 {
-    public const IDENTIFIER = 'DECIMAL';
+    public const IDENTIFIER = 'MONEY_TO_DECIMAL';
 
     private $field;
     private $precision;
@@ -39,7 +39,7 @@ class DecimalCastFunction extends FunctionNode
     {
         $field = $this->field->dispatch($sqlWalker);
         $precision = $this->precision->dispatch($sqlWalker);
-        $dividend = (int)str_pad('1', $precision + 1, '0', STR_PAD_RIGHT);
+        $dividend = (int) str_pad('1', $precision + 1, '0', STR_PAD_RIGHT);
 
         return "(($field)::NUMERIC / $dividend)::NUMERIC(10, $precision)";
     }


### PR DESCRIPTION
Se agregaron dos nuevas extensiones:
- DECIMAL
- LPAD

Ejemplo para total.amount = 5025:
```
$qb->select('DECIMAL(total.amount, 0)');  // 5025
$qb->select('DECIMAL(total.amount, 1)');  // 502.5
$qb->select('DECIMAL(total.amount, 2)');  // 50.25
$qb->select('DECIMAL(total.amount, 3)');  // 5.025
$qb->select('DECIMAL(total.amount, 4)');  // 0.5025
```

NOTA:
- Una cantidad **negativa** de decimales resulta en un error de SQL (propio de la función DECIMAL.
- Como nosotros usamos Money, y el valor se almacena como **string** en la DB, para hacer operaciones aritméticas antes de convertirlo a decimal hay que castear el valor a NUMERIC.