### PR TITLE
PCT-11261 | Add Laravel 11 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "mockery/mockery": "^1.0",
         "laravel-doctrine/orm": "^3.2",
         "laravel-doctrine/fluent": "^3.0",
-        "illuminate/support": "^10.0",
+        "illuminate/support": "^10.0 || ^11.0",
         "ramsey/uuid": "^4.1"
     },
     "autoload": {


### PR DESCRIPTION
Widens illuminate/support dev constraint to include ^11.0 for the L10 → L13 upgrade project. Package has no runtime Laravel deps; this only affects package's own test matrix.