### PR TITLE
PCT-11261 | Doctrine DBAL 4 compatibility

### DIFF
--- a/src/Types/ChronosDateTimeType.php
+++ b/src/Types/ChronosDateTimeType.php
@@ -3,30 +3,18 @@
 namespace Digbang\DoctrineExtensions\Types;
 
 use Cake\Chronos\Chronos;
+use DateTimeImmutable;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
-use Doctrine\DBAL\Types\DateTimeType;
+use Doctrine\DBAL\Types\DateTimeImmutableType;
 
-class ChronosDateTimeType extends DateTimeType
+class ChronosDateTimeType extends DateTimeImmutableType
 {
     const CHRONOS_DATETIME = 'chronos_datetime';
 
-    public function getName()
+    public function convertToPHPValue(mixed $value, AbstractPlatform $platform): ?DateTimeImmutable
     {
-        return static::CHRONOS_DATETIME;
-    }
-
-    public function convertToPHPValue($value, AbstractPlatform $platform)
-    {
-        if ($value === null) {
-            return null;
-        }
         $dateTime = parent::convertToPHPValue($value, $platform);
 
-        return Chronos::instance($dateTime);
-    }
-
-    public function requiresSQLCommentHint(AbstractPlatform $platform)
-    {
-        return true;
+        return $dateTime === null ? null : Chronos::instance($dateTime);
     }
 }

--- a/src/Types/ChronosDateTimeTzType.php
+++ b/src/Types/ChronosDateTimeTzType.php
@@ -3,30 +3,18 @@
 namespace Digbang\DoctrineExtensions\Types;
 
 use Cake\Chronos\Chronos;
+use DateTimeImmutable;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
-use Doctrine\DBAL\Types\DateTimeTzType;
+use Doctrine\DBAL\Types\DateTimeTzImmutableType;
 
-class ChronosDateTimeTzType extends DateTimeTzType
+class ChronosDateTimeTzType extends DateTimeTzImmutableType
 {
     const CHRONOS_DATETIMETZ = 'chronos_datetimetz';
 
-    public function getName()
+    public function convertToPHPValue(mixed $value, AbstractPlatform $platform): ?DateTimeImmutable
     {
-        return static::CHRONOS_DATETIMETZ;
-    }
-
-    public function convertToPHPValue($value, AbstractPlatform $platform)
-    {
-        if ($value === null) {
-            return null;
-        }
         $dateTime = parent::convertToPHPValue($value, $platform);
 
-        return Chronos::instance($dateTime);
-    }
-
-    public function requiresSQLCommentHint(AbstractPlatform $platform)
-    {
-        return true;
+        return $dateTime === null ? null : Chronos::instance($dateTime);
     }
 }

--- a/src/Types/ChronosDateType.php
+++ b/src/Types/ChronosDateType.php
@@ -3,30 +3,18 @@
 namespace Digbang\DoctrineExtensions\Types;
 
 use Cake\Chronos\Date;
+use DateTimeImmutable;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
-use Doctrine\DBAL\Types\DateType;
+use Doctrine\DBAL\Types\DateImmutableType;
 
-class ChronosDateType extends DateType
+class ChronosDateType extends DateImmutableType
 {
     const CHRONOS_DATE = 'chronos_date';
 
-    public function getName()
+    public function convertToPHPValue(mixed $value, AbstractPlatform $platform): ?DateTimeImmutable
     {
-        return static::CHRONOS_DATE;
-    }
-
-    public function convertToPHPValue($value, AbstractPlatform $platform)
-    {
-        if ($value === null) {
-            return null;
-        }
         $dateTime = parent::convertToPHPValue($value, $platform);
 
-        return Date::instance($dateTime);
-    }
-
-    public function requiresSQLCommentHint(AbstractPlatform $platform)
-    {
-        return true;
+        return $dateTime === null ? null : Date::instance($dateTime);
     }
 }

--- a/src/Types/UuidType.php
+++ b/src/Types/UuidType.php
@@ -28,32 +28,17 @@ use Ramsey\Uuid\Uuid;
  */
 class UuidType extends Type
 {
-    /**
-     * @var string
-     */
     const UUID = 'uuid';
 
-    /**
-     * {@inheritdoc}
-     *
-     * @param array                                     $fieldDeclaration
-     * @param \Doctrine\DBAL\Platforms\AbstractPlatform $platform
-     */
-    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
+    public function getSQLDeclaration(array $column, AbstractPlatform $platform): string
     {
-        return $platform->getGuidTypeDeclarationSQL($fieldDeclaration);
+        return $platform->getGuidTypeDeclarationSQL($column);
     }
 
-    /**
-     * {@inheritdoc}
-     *
-     * @param string|null                               $value
-     * @param \Doctrine\DBAL\Platforms\AbstractPlatform $platform
-     */
-    public function convertToPHPValue($value, AbstractPlatform $platform)
+    public function convertToPHPValue(mixed $value, AbstractPlatform $platform): mixed
     {
         if (empty($value)) {
-            return;
+            return null;
         }
 
         if ($value instanceof Uuid) {
@@ -69,16 +54,10 @@ class UuidType extends Type
         return $uuid;
     }
 
-    /**
-     * {@inheritdoc}
-     *
-     * @param Uuid|null                                 $value
-     * @param \Doctrine\DBAL\Platforms\AbstractPlatform $platform
-     */
-    public function convertToDatabaseValue($value, AbstractPlatform $platform)
+    public function convertToDatabaseValue(mixed $value, AbstractPlatform $platform): mixed
     {
         if (empty($value)) {
-            return;
+            return null;
         }
 
         if ($value instanceof Uuid || Uuid::isValid($value)) {
@@ -86,27 +65,5 @@ class UuidType extends Type
         }
 
         throw ConversionException::conversionFailed($value, self::UUID);
-    }
-
-    /**
-     * {@inheritdoc}
-     *
-     * @return string
-     */
-    public function getName()
-    {
-        return self::UUID;
-    }
-
-    /**
-     * {@inheritdoc}
-     *
-     * @param \Doctrine\DBAL\Platforms\AbstractPlatform $platform
-     *
-     * @return bool
-     */
-    public function requiresSQLCommentHint(AbstractPlatform $platform)
-    {
-        return true;
     }
 }


### PR DESCRIPTION
DBAL 4 tightens Type method signatures (mixed $value, explicit return types) and removes getName()/requiresSQLCommentHint() hooks. Chronos*Type classes now extend the Immutable variants so ?DateTimeImmutable return type lines up with Chronos/ChronosDate (both descend from DateTimeImmutable). UuidType also gets the new mixed+mixed signatures.